### PR TITLE
Improve UX of lightness bar

### DIFF
--- a/lib/flutter_circle_color_picker.dart
+++ b/lib/flutter_circle_color_picker.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 typedef ColorCodeBuilder = Widget Function(BuildContext context, Color color);
 
@@ -123,6 +122,7 @@ class _CircleColorPickerState extends State<CircleColorPicker>
             onEnded: _onEnded,
             onChanged: (hue) {
               _hueController.value = hue;
+              _lightnessController.value = 0.5;
             },
           ),
           if (!widget.hideLightnessBar)


### PR DESCRIPTION
#### Problem from MyBook
When user first picks a color for the textbox, it seems like the color is broken. The lightness bar is set to as dark as possible to make black (for the initial color) so no matter what color the user selects, it doesn't change the color.

#### Toggl
https://plan.toggl.com/#timeline/621922/boards/2979155?task=39851673

#### Fix
If user changes color wheel, but lightness bar back to .5